### PR TITLE
Simplify 'using' statements in unit tests.

### DIFF
--- a/Test/UnitTests/CascadeSoftDeleteTests/TestHardDeleteCascadeSoftDelete.cs
+++ b/Test/UnitTests/CascadeSoftDeleteTests/TestHardDeleteCascadeSoftDelete.cs
@@ -33,24 +33,22 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
-                var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
-                numSoftDeleted.ShouldEqual(7 + 6);
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
+            numSoftDeleted.ShouldEqual(7 + 6);
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
 
-                //ATTEMPT
-                var status = service.CheckCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"));
+            //ATTEMPT
+            var status = service.CheckCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"));
 
-                //VERIFY
-                status.Result.ShouldEqual(7 + 6);
-                status.Message.ShouldEqual("Are you sure you want to hard delete this entity and its 12 dependents");
-            }
+            //VERIFY
+            status.Result.ShouldEqual(7 + 6);
+            status.Message.ShouldEqual("Are you sure you want to hard delete this entity and its 12 dependents");
         }
 
         [Fact]
@@ -58,22 +56,20 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.CheckCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "ProjectManager1"));
+            //ATTEMPT
+            var status = service.CheckCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "ProjectManager1"));
 
-                //VERIFY
-                status.IsValid.ShouldBeFalse();
-                status.Result.ShouldEqual(0);
-                status.GetAllErrors().ShouldEqual("This entry isn't soft deleted.");
-            }
+            //VERIFY
+            status.IsValid.ShouldBeFalse();
+            status.Result.ShouldEqual(0);
+            status.GetAllErrors().ShouldEqual("This entry isn't soft deleted.");
         }
 
         //---------------------------------------------------------
@@ -84,26 +80,24 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
-                var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
-                numSoftDeleted.ShouldEqual(7 + 6);
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
+            numSoftDeleted.ShouldEqual(7 + 6);
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
 
-                //ATTEMPT
-                var status = service.HardDeleteSoftDeletedEntries(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"));
+            //ATTEMPT
+            var status = service.HardDeleteSoftDeletedEntries(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"));
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(7 + 6);
-                status.Message.ShouldEqual("You have hard deleted an entity and its 12 dependents");
-                context.Employees.IgnoreQueryFilters().Count().ShouldEqual(4);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(7 + 6);
+            status.Message.ShouldEqual("You have hard deleted an entity and its 12 dependents");
+            context.Employees.IgnoreQueryFilters().Count().ShouldEqual(4);
         }
 
         [Fact]
@@ -111,28 +105,26 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
-                var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
-                numSoftDeleted.ShouldEqual(7 + 6);
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
+            numSoftDeleted.ShouldEqual(7 + 6);
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
 
-                //ATTEMPT
-                var status = service.HardDeleteSoftDeletedEntries(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"), false);
-                context.Employees.IgnoreQueryFilters().Count().ShouldEqual(11);
-                context.SaveChanges();
-                context.Employees.IgnoreQueryFilters().Count().ShouldEqual(4);
+            //ATTEMPT
+            var status = service.HardDeleteSoftDeletedEntries(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"), false);
+            context.Employees.IgnoreQueryFilters().Count().ShouldEqual(11);
+            context.SaveChanges();
+            context.Employees.IgnoreQueryFilters().Count().ShouldEqual(4);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(7 + 6);
-                status.Message.ShouldEqual("You have hard deleted an entity and its 12 dependents");
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(7 + 6);
+            status.Message.ShouldEqual("You have hard deleted an entity and its 12 dependents");
         }
 
         [Fact]
@@ -140,22 +132,20 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.HardDeleteSoftDeletedEntries(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "ProjectManager1"));
+            //ATTEMPT
+            var status = service.HardDeleteSoftDeletedEntries(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "ProjectManager1"));
 
-                //VERIFY
-                status.IsValid.ShouldBeFalse();
-                status.Result.ShouldEqual(0);
-                status.GetAllErrors().ShouldEqual("This entry isn't soft deleted.");
-            }
+            //VERIFY
+            status.IsValid.ShouldBeFalse();
+            status.Result.ShouldEqual(0);
+            status.GetAllErrors().ShouldEqual("This entry isn't soft deleted.");
         }
 
         //------------------------------------------------------------
@@ -167,27 +157,25 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
             //SETUP
             var userId = Guid.NewGuid();
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options, userId))
-            {
-                context.Database.EnsureCreated();
-                var company = Company.SeedCompanyWithQuotes(context, userId);
-                Company.SeedCompanyWithQuotes(context, Guid.Empty, "Other company");
-                context.SaveChanges();
+            using var context = new CascadeSoftDelDbContext(options, userId);
+            context.Database.EnsureCreated();
+            var company = Company.SeedCompanyWithQuotes(context, userId);
+            Company.SeedCompanyWithQuotes(context, Guid.Empty, "Other company");
+            context.SaveChanges();
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
-                service.SetCascadeSoftDelete(company).Result.ShouldEqual(1 + 4 + 4);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            service.SetCascadeSoftDelete(company).Result.ShouldEqual(1 + 4 + 4);
 
-                //ATTEMPT
-                var status = service.HardDeleteSoftDeletedEntries(company);
+            //ATTEMPT
+            var status = service.HardDeleteSoftDeletedEntries(company);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1 + 4 + 4);
-                status.Message.ShouldEqual("You have hard deleted an entity and its 8 dependents");
-                context.Quotes.Count().ShouldEqual(0);  
-                context.Quotes.IgnoreQueryFilters().Count().ShouldEqual(4); 
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1 + 4 + 4);
+            status.Message.ShouldEqual("You have hard deleted an entity and its 8 dependents");
+            context.Quotes.Count().ShouldEqual(0);
+            context.Quotes.IgnoreQueryFilters().Count().ShouldEqual(4);
         }
 
     }

--- a/Test/UnitTests/CascadeSoftDeleteTests/TestResetCascadeSoftDelete.cs
+++ b/Test/UnitTests/CascadeSoftDeleteTests/TestResetCascadeSoftDelete.cs
@@ -33,27 +33,25 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
-                numSoftDeleted.ShouldEqual(7 + 6);
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
+            numSoftDeleted.ShouldEqual(7 + 6);
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
 
-                //ATTEMPT
-                var status = service.ResetCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"));
+            //ATTEMPT
+            var status = service.ResetCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"));
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(7 + 6);
-                context.Employees.Count().ShouldEqual(11);
-                context.Contracts.Count().ShouldEqual(9);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(7 + 6);
+            context.Employees.Count().ShouldEqual(11);
+            context.Contracts.Count().ShouldEqual(9);
         }
 
         [Fact]
@@ -61,30 +59,28 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
-                numSoftDeleted.ShouldEqual(7 + 6);
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
+            numSoftDeleted.ShouldEqual(7 + 6);
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
 
-                //ATTEMPT
-                var status = service.ResetCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"), false);
-                context.Employees.Count().ShouldEqual(11-7);
-                context.Contracts.Count().ShouldEqual(9-6);
-                context.SaveChanges();
-                context.Employees.Count().ShouldEqual(11);
-                context.Contracts.Count().ShouldEqual(9);
+            //ATTEMPT
+            var status = service.ResetCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"), false);
+            context.Employees.Count().ShouldEqual(11 - 7);
+            context.Contracts.Count().ShouldEqual(9 - 6);
+            context.SaveChanges();
+            context.Employees.Count().ShouldEqual(11);
+            context.Contracts.Count().ShouldEqual(9);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(7 + 6);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(7 + 6);
         }
 
         [Fact]
@@ -92,26 +88,24 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
-                numSoftDeleted.ShouldEqual(7 + 6);
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
+            numSoftDeleted.ShouldEqual(7 + 6);
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
 
-                //ATTEMPT
-                var status = service.ResetCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"));
+            //ATTEMPT
+            var status = service.ResetCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"));
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(7 + 6);
-                status.Message.ShouldEqual("You have recovered an entity and its 12 dependents");
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(7 + 6);
+            status.Message.ShouldEqual("You have recovered an entity and its 12 dependents");
         }
 
         [Fact]
@@ -119,27 +113,25 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
-                numSoftDeleted.ShouldEqual(7 + 6);
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
+            numSoftDeleted.ShouldEqual(7 + 6);
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
 
-                //ATTEMPT
-                var status = service.ResetCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "ProjectManager1"));
+            //ATTEMPT
+            var status = service.ResetCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "ProjectManager1"));
 
-                //VERIFY
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
-                status.IsValid.ShouldBeFalse();
-                status.GetAllErrors().ShouldEqual("This entry was soft deleted 1 level above here");
-                status.Result.ShouldEqual(0);
-            }
+            //VERIFY
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            status.IsValid.ShouldBeFalse();
+            status.GetAllErrors().ShouldEqual("This entry was soft deleted 1 level above here");
+            status.Result.ShouldEqual(0);
         }
 
         [Fact]
@@ -147,30 +139,28 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                var numInnerSoftDelete = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "ProjectManager1")).Result;
-                numInnerSoftDelete.ShouldEqual(3 + 3);
-                var numOuterSoftDelete = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
-                numOuterSoftDelete.ShouldEqual(4 + 3);
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            var numInnerSoftDelete = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "ProjectManager1")).Result;
+            numInnerSoftDelete.ShouldEqual(3 + 3);
+            var numOuterSoftDelete = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
+            numOuterSoftDelete.ShouldEqual(4 + 3);
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
 
-                //ATTEMPT
-                var status = service.ResetCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"));
+            //ATTEMPT
+            var status = service.ResetCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"));
 
-                //VERIFY
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(4 + 3);
-                var cto = context.Employees.Include(x => x.WorksFromMe).Single(x => x.Name == "CTO");
-                cto.WorksFromMe.Single(x => x.SoftDeleteLevel == 0).Name.ShouldEqual("ProjectManager2");
-            }
+            //VERIFY
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(4 + 3);
+            var cto = context.Employees.Include(x => x.WorksFromMe).Single(x => x.Name == "CTO");
+            cto.WorksFromMe.Single(x => x.SoftDeleteLevel == 0).Name.ShouldEqual("ProjectManager2");
         }
 
         //-------------------------------------------------------------
@@ -181,32 +171,29 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            using var setupContext = new CascadeSoftDelDbContext(options);            
+            setupContext.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(setupContext);
 
-                var numSoftDeleted = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO")).Result;
-                numSoftDeleted.ShouldEqual(7+6);
-            }
+            var setupConfig = new ConfigCascadeDeleteWithUserId(setupContext);
+            var setupService = new CascadeSoftDelService<ICascadeSoftDelete>(setupContext, setupConfig);
 
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var numSoftDeleted = setupService.SetCascadeSoftDelete(setupContext.Employees.Single(x => x.Name == "CTO")).Result;
+            numSoftDeleted.ShouldEqual(7+6);            
 
-                //ATTEMPT
-                var status = service.ResetCascadeSoftDelete(context.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"));
-
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(7 + 6);
-                context.Employees.Count().ShouldEqual(11);
-                context.Contracts.Count().ShouldEqual(9);
-            }
+            using var testContext = new CascadeSoftDelDbContext(options);
+            var testConfig = new ConfigCascadeDeleteWithUserId(testContext);
+            var testService = new CascadeSoftDelService<ICascadeSoftDelete>(testContext, testConfig);
+            
+            //ATTEMPT
+            var status = testService.ResetCascadeSoftDelete(testContext.Employees.IgnoreQueryFilters().Single(x => x.Name == "CTO"));
+            
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(7 + 6);
+            testContext.Employees.Count().ShouldEqual(11);
+            testContext.Contracts.Count().ShouldEqual(9);
         }
 
         //------------------------------------------------------------
@@ -218,33 +205,29 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
             //SETUP
             var userId = Guid.NewGuid();
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options, userId))
-            {
-                context.Database.EnsureCreated();
-                var company = Company.SeedCompanyWithQuotes(context, userId);
-                company.Quotes.First().UserId = Guid.NewGuid();
-                company.Quotes.First().SoftDeleteLevel = 1;  //Set to deleted
-                context.SaveChanges();
+            using var setupContext = new CascadeSoftDelDbContext(options, userId);
+            setupContext.Database.EnsureCreated();
+            var company = Company.SeedCompanyWithQuotes(setupContext, userId);
+            company.Quotes.First().UserId = Guid.NewGuid();
+            company.Quotes.First().SoftDeleteLevel = 1;  //Set to deleted
+            setupContext.SaveChanges();
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
-                service.SetCascadeSoftDelete(company).Result.ShouldEqual(1 + 3 + 3);
-            }
+            var setupConfig = new ConfigCascadeDeleteWithUserId(setupContext);
+            var setupService = new CascadeSoftDelService<ICascadeSoftDelete>(setupContext, setupConfig);
+            setupService.SetCascadeSoftDelete(company).Result.ShouldEqual(1 + 3 + 3);            
 
-            using (var context = new CascadeSoftDelDbContext(options, userId))
-            {
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            using var testContext = new CascadeSoftDelDbContext(options, userId);
+            var testConfig = new ConfigCascadeDeleteWithUserId(testContext);
+            var testService = new CascadeSoftDelService<ICascadeSoftDelete>(testContext, testConfig);
 
-                //ATTEMPT
-                var status = service.ResetCascadeSoftDelete(context.Companies.IgnoreQueryFilters().Single());
+            //ATTEMPT
+            var status = testService.ResetCascadeSoftDelete(testContext.Companies.IgnoreQueryFilters().Single());
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1 + 3 + 3);
-                status.Message.ShouldEqual("You have recovered an entity and its 6 dependents");
-                context.Quotes.Count().ShouldEqual(3);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1 + 3 + 3);
+            status.Message.ShouldEqual("You have recovered an entity and its 6 dependents");
+            testContext.Quotes.Count().ShouldEqual(3);
         }
 
     }

--- a/Test/UnitTests/CascadeSoftDeleteTests/TestSetCascadeSoftDelete.cs
+++ b/Test/UnitTests/CascadeSoftDeleteTests/TestSetCascadeSoftDelete.cs
@@ -33,18 +33,16 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
 
-                //ATTEMPT
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            //ATTEMPT
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                //VERIFY
-                context.Employees.Count().ShouldEqual(11);
-                context.Contracts.Count().ShouldEqual(9);
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
-            }
+            //VERIFY
+            context.Employees.Count().ShouldEqual(11);
+            context.Contracts.Count().ShouldEqual(9);
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
         }
 
         [Fact]
@@ -52,19 +50,17 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                //ATTEMPT
-                context.Remove(ceo.WorksFromMe.First());
-                context.SaveChanges();
+            //ATTEMPT
+            context.Remove(ceo.WorksFromMe.First());
+            context.SaveChanges();
 
-                //VERIFY
-                context.Employees.Count().ShouldEqual(4);
-                context.Contracts.Count().ShouldEqual(3);
-            }
+            //VERIFY
+            context.Employees.Count().ShouldEqual(4);
+            context.Contracts.Count().ShouldEqual(3);
         }
 
         [Fact]
@@ -72,18 +68,16 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                //ATTEMPT
-                ceo.WorksFromMe.First().SoftDeleteLevel = 1;
-                context.SaveChanges();
+            //ATTEMPT
+            ceo.WorksFromMe.First().SoftDeleteLevel = 1;
+            context.SaveChanges();
 
-                //VERIFY
-                context.Employees.Count().ShouldEqual(10);
-            }
+            //VERIFY
+            context.Employees.Count().ShouldEqual(10);
         }
 
         [Fact]
@@ -91,24 +85,22 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.SetCascadeSoftDelete(ceo.WorksFromMe.First());
+            //ATTEMPT
+            var status = service.SetCascadeSoftDelete(ceo.WorksFromMe.First());
 
-                //VERIFY
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(7 + 6);
-                context.Employees.IgnoreQueryFilters().Count(x => x.SoftDeleteLevel != 0).ShouldEqual(7);
-                status.Message.ShouldEqual("You have soft deleted an entity and its 12 dependents");
-            }
+            //VERIFY
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(7 + 6);
+            context.Employees.IgnoreQueryFilters().Count(x => x.SoftDeleteLevel != 0).ShouldEqual(7);
+            status.Message.ShouldEqual("You have soft deleted an entity and its 12 dependents");
         }
 
         [Fact]
@@ -116,26 +108,24 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.SetCascadeSoftDelete(ceo.WorksFromMe.First(), false);
-                context.Employees.IgnoreQueryFilters().Count(x => x.SoftDeleteLevel != 0).ShouldEqual(0);
-                context.SaveChanges();
-                context.Employees.IgnoreQueryFilters().Count(x => x.SoftDeleteLevel != 0).ShouldEqual(7);
+            //ATTEMPT
+            var status = service.SetCascadeSoftDelete(ceo.WorksFromMe.First(), false);
+            context.Employees.IgnoreQueryFilters().Count(x => x.SoftDeleteLevel != 0).ShouldEqual(0);
+            context.SaveChanges();
+            context.Employees.IgnoreQueryFilters().Count(x => x.SoftDeleteLevel != 0).ShouldEqual(7);
 
-                //VERIFY
-                //Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
-                status.Result.ShouldEqual(7 + 6);
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Message.ShouldEqual("You have soft deleted an entity and its 12 dependents");
-            }
+            //VERIFY
+            //Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            status.Result.ShouldEqual(7 + 6);
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Message.ShouldEqual("You have soft deleted an entity and its 12 dependents");
         }
 
         [Fact]
@@ -143,22 +133,20 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
-                service.SetCascadeSoftDelete(ceo.WorksFromMe.First()).IsValid.ShouldBeTrue();
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            service.SetCascadeSoftDelete(ceo.WorksFromMe.First()).IsValid.ShouldBeTrue();
 
-                //ATTEMPT
-                var softDeleted = service.GetSoftDeletedEntries<Employee>().ToList();
+            //ATTEMPT
+            var softDeleted = service.GetSoftDeletedEntries<Employee>().ToList();
 
-                //VERIFY
-                softDeleted.Count.ShouldEqual(1);
-                softDeleted.Single().Name.ShouldEqual(ceo.WorksFromMe.First().Name);
-            }
+            //VERIFY
+            softDeleted.Count.ShouldEqual(1);
+            softDeleted.Single().Name.ShouldEqual(ceo.WorksFromMe.First().Name);
         }
 
         [Fact]
@@ -166,20 +154,18 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                //ATTEMPT
-                var ex = Assert.Throws<InvalidOperationException>(() => service.SetCascadeSoftDelete(ceo.WorksFromMe.First().Contract));
+            //ATTEMPT
+            var ex = Assert.Throws<InvalidOperationException>(() => service.SetCascadeSoftDelete(ceo.WorksFromMe.First().Contract));
 
-                //VERIFY
-                ex.Message.ShouldEqual("You cannot soft delete a one-to-one relationship. It causes problems if you try to create a new version.");
-            }
+            //VERIFY
+            ex.Message.ShouldEqual("You cannot soft delete a one-to-one relationship. It causes problems if you try to create a new version.");
         }
 
         [Fact]
@@ -187,31 +173,29 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.SetCascadeSoftDelete(ceo.WorksFromMe.First());
+            //ATTEMPT
+            var status = service.SetCascadeSoftDelete(ceo.WorksFromMe.First());
 
-                //VERIFY
-                //Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(7 + 6);
-                context.Employees.Count().ShouldEqual(4);
-                context.Employees.IgnoreQueryFilters().Count().ShouldEqual(11);
-                context.Employees.IgnoreQueryFilters().Select(x => x.SoftDeleteLevel).Where(x => x > 0).ToArray()
-                    .ShouldEqual(new byte[] { 1, 2, 2, 3, 3, 3, 3 });
-                context.Contracts.Count().ShouldEqual(3);
-                context.Contracts.IgnoreQueryFilters().Count().ShouldEqual(9);
-                context.Employees.IgnoreQueryFilters().Select(x => x.Contract).Where(x => x != null)
-                    .Select(x => x.SoftDeleteLevel).Where(x => x > 0).ToArray()
-                    .ShouldEqual(new byte[] { 2, 3, 3, 4, 4, 4 });
-            }
+            //VERIFY
+            //Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(7 + 6);
+            context.Employees.Count().ShouldEqual(4);
+            context.Employees.IgnoreQueryFilters().Count().ShouldEqual(11);
+            context.Employees.IgnoreQueryFilters().Select(x => x.SoftDeleteLevel).Where(x => x > 0).ToArray()
+                .ShouldEqual(new byte[] { 1, 2, 2, 3, 3, 3, 3 });
+            context.Contracts.Count().ShouldEqual(3);
+            context.Contracts.IgnoreQueryFilters().Count().ShouldEqual(9);
+            context.Employees.IgnoreQueryFilters().Select(x => x.Contract).Where(x => x != null)
+                .Select(x => x.SoftDeleteLevel).Where(x => x > 0).ToArray()
+                .ShouldEqual(new byte[] { 2, 3, 3, 4, 4, 4 });
         }
 
         [Theory]
@@ -222,35 +206,33 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
             //SETUP
             var logs = new List<string>();
             var options = SqliteInMemory.CreateOptionsWithLogging<CascadeSoftDelDbContext>(log => logs.Add(log.DecodeMessage()));
-            using (var context = new CascadeSoftDelDbContext(options))
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
+
+            var config = new ConfigCascadeDeleteWithUserId(context)
             {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+                ReadEveryTime = readEveryTime
+            };
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                var config = new ConfigCascadeDeleteWithUserId(context)
-                {
-                    ReadEveryTime = readEveryTime
-                };
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            //ATTEMPT
+            logs.Clear();
+            var status = service.SetCascadeSoftDelete(ceo.WorksFromMe.First());
 
-                //ATTEMPT
-                logs.Clear();
-                var status = service.SetCascadeSoftDelete(ceo.WorksFromMe.First());
-
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                logs.Count(x =>  _selectMatchRegex.IsMatch(x)).ShouldEqual(selectCount);
-                status.Result.ShouldEqual(7 + 6);
-                context.Employees.Count().ShouldEqual(4);
-                context.Employees.IgnoreQueryFilters().Count().ShouldEqual(11);
-                context.Employees.IgnoreQueryFilters().Select(x => x.SoftDeleteLevel).Where(x => x > 0).ToArray()
-                    .ShouldEqual(new byte[] { 1, 2, 2, 3, 3, 3, 3 });
-                context.Contracts.Count().ShouldEqual(3);
-                context.Contracts.IgnoreQueryFilters().Count().ShouldEqual(9);
-                context.Employees.IgnoreQueryFilters().Select(x => x.Contract).Where(x => x != null)
-                    .Select(x => x.SoftDeleteLevel).Where(x => x > 0).ToArray()
-                    .ShouldEqual(new byte[] { 2, 3, 3, 4, 4, 4 });
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            logs.Count(x => _selectMatchRegex.IsMatch(x)).ShouldEqual(selectCount);
+            status.Result.ShouldEqual(7 + 6);
+            context.Employees.Count().ShouldEqual(4);
+            context.Employees.IgnoreQueryFilters().Count().ShouldEqual(11);
+            context.Employees.IgnoreQueryFilters().Select(x => x.SoftDeleteLevel).Where(x => x > 0).ToArray()
+                .ShouldEqual(new byte[] { 1, 2, 2, 3, 3, 3, 3 });
+            context.Contracts.Count().ShouldEqual(3);
+            context.Contracts.IgnoreQueryFilters().Count().ShouldEqual(9);
+            context.Employees.IgnoreQueryFilters().Select(x => x.Contract).Where(x => x != null)
+                .Select(x => x.SoftDeleteLevel).Where(x => x > 0).ToArray()
+                .ShouldEqual(new byte[] { 2, 3, 3, 4, 4, 4 });
         }
 
         [Fact]
@@ -258,35 +240,33 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
-                
-                var preNumSoftDeleted = service.SetCascadeSoftDelete(ceo.WorksFromMe.First().WorksFromMe.First()).Result;
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.SetCascadeSoftDelete(ceo.WorksFromMe.First());
+            var preNumSoftDeleted = service.SetCascadeSoftDelete(ceo.WorksFromMe.First().WorksFromMe.First()).Result;
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
 
-                //VERIFY
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                preNumSoftDeleted.ShouldEqual(3 + 3);
-                status.Result.ShouldEqual(4 + 3);
-                context.Employees.Count().ShouldEqual(4);
-                context.Employees.IgnoreQueryFilters().Count().ShouldEqual(11);
-                context.Employees.IgnoreQueryFilters().Select(x => x.SoftDeleteLevel).Where(x => x > 0).ToArray()
-                    .ShouldEqual(new byte[] { 1, 1, 2, 2, 2, 3, 3 });
-                context.Contracts.Count().ShouldEqual(3);
-                context.Contracts.IgnoreQueryFilters().Count().ShouldEqual(9);
-                context.Employees.IgnoreQueryFilters().Select(x => x.Contract).Where(x => x != null)
-                    .Select(x => x.SoftDeleteLevel).Where(x => x > 0)
-                    .ToArray().ShouldEqual(new byte[] { 2, 2, 3, 3, 3, 4 });
-            }
+            //ATTEMPT
+            var status = service.SetCascadeSoftDelete(ceo.WorksFromMe.First());
+
+            //VERIFY
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            preNumSoftDeleted.ShouldEqual(3 + 3);
+            status.Result.ShouldEqual(4 + 3);
+            context.Employees.Count().ShouldEqual(4);
+            context.Employees.IgnoreQueryFilters().Count().ShouldEqual(11);
+            context.Employees.IgnoreQueryFilters().Select(x => x.SoftDeleteLevel).Where(x => x > 0).ToArray()
+                .ShouldEqual(new byte[] { 1, 1, 2, 2, 2, 3, 3 });
+            context.Contracts.Count().ShouldEqual(3);
+            context.Contracts.IgnoreQueryFilters().Count().ShouldEqual(9);
+            context.Employees.IgnoreQueryFilters().Select(x => x.Contract).Where(x => x != null)
+                .Select(x => x.SoftDeleteLevel).Where(x => x > 0)
+                .ToArray().ShouldEqual(new byte[] { 2, 2, 3, 3, 3, 4 });
         }
 
         [Fact]
@@ -294,35 +274,33 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                //ATTEMPT
-                var numInnerSoftDelete = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "ProjectManager1")).Result;
-                numInnerSoftDelete.ShouldEqual(3 + 3);
-                var status = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO"));
+            //ATTEMPT
+            var numInnerSoftDelete = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "ProjectManager1")).Result;
+            numInnerSoftDelete.ShouldEqual(3 + 3);
+            var status = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO"));
 
-                //VERIFY
-                Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(4 + 3);
-                context.Employees.Count().ShouldEqual(4);
-                context.Employees.IgnoreQueryFilters().Count().ShouldEqual(11);
-                context.Employees.IgnoreQueryFilters().Select(x => x.SoftDeleteLevel).Where(x => x > 0)
-                    //.ToList().ForEach(x => _output.WriteLine(x.ToString()));
-                    .ToArray().ShouldEqual(new byte[] { 1, 1, 2, 2,2, 3,3 });
-                context.Contracts.Count().ShouldEqual(3);
-                context.Contracts.IgnoreQueryFilters().Count().ShouldEqual(9);
-                context.Employees.IgnoreQueryFilters().Select(x => x.Contract).Where(x => x != null)
-                    .Select(x => x.SoftDeleteLevel).Where(x => x > 0)
-                    //.ToList().ForEach(x => _output.WriteLine(x.ToString()));
-                    .ToArray().ShouldEqual(new byte[] { 2, 2, 3, 3, 3, 4 });
-            }
+            //VERIFY
+            Employee.ShowHierarchical(ceo, x => _output.WriteLine(x), false);
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(4 + 3);
+            context.Employees.Count().ShouldEqual(4);
+            context.Employees.IgnoreQueryFilters().Count().ShouldEqual(11);
+            context.Employees.IgnoreQueryFilters().Select(x => x.SoftDeleteLevel).Where(x => x > 0)
+                //.ToList().ForEach(x => _output.WriteLine(x.ToString()));
+                .ToArray().ShouldEqual(new byte[] { 1, 1, 2, 2, 2, 3, 3 });
+            context.Contracts.Count().ShouldEqual(3);
+            context.Contracts.IgnoreQueryFilters().Count().ShouldEqual(9);
+            context.Employees.IgnoreQueryFilters().Select(x => x.Contract).Where(x => x != null)
+                .Select(x => x.SoftDeleteLevel).Where(x => x > 0)
+                //.ToList().ForEach(x => _output.WriteLine(x.ToString()));
+                .ToArray().ShouldEqual(new byte[] { 2, 2, 3, 3, 3, 4 });
         }
 
         [Fact]
@@ -330,24 +308,21 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
-                var devEntry = context.Employees.Single(x => x.Name == "dev1a");
-                devEntry.WorksFromMe = new List<Employee>{ devEntry.Manager.Manager};
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
+            var devEntry = context.Employees.Single(x => x.Name == "dev1a");
+            devEntry.WorksFromMe = new List<Employee> { devEntry.Manager.Manager };
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO"));
+            //ATTEMPT
+            var status = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO"));
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(7+6);
-                
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(7 + 6);
         }
 
         //---------------------------------------------------------
@@ -361,32 +336,29 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
             //SETUP
             var logs = new List<string>();
             var options = SqliteInMemory.CreateOptionsWithLogging<CascadeSoftDelDbContext>(log => logs.Add(log.DecodeMessage()));
-            using (var context = new CascadeSoftDelDbContext(options))
+            using var setupContext = new CascadeSoftDelDbContext(options);            
+            setupContext.Database.EnsureCreated();
+            Employee.SeedEmployeeSoftDel(setupContext);
+            
+            using var testContext = new CascadeSoftDelDbContext(options);
+            var config = new ConfigCascadeDeleteWithUserId(testContext)
             {
-                context.Database.EnsureCreated();
-                Employee.SeedEmployeeSoftDel(context);
-            }
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                var config = new ConfigCascadeDeleteWithUserId(context)
-                {
-                    ReadEveryTime = readEveryTime
-                };
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+                ReadEveryTime = readEveryTime
+            };
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(testContext, config);
 
-                //ATTEMPT
-                logs.Clear();
-                var status = service.SetCascadeSoftDelete(context.Employees.Single(x => x.Name == "CTO"));
+            //ATTEMPT
+            logs.Clear();
+            var status = service.SetCascadeSoftDelete(testContext.Employees.Single(x => x.Name == "CTO"));
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                logs.Count(x => _selectMatchRegex.IsMatch(x)).ShouldEqual(7);
-                status.Result.ShouldEqual(7+6);
-                context.Employees.Count().ShouldEqual(4);
-                context.Employees.IgnoreQueryFilters().Count().ShouldEqual(11);
-                context.Contracts.Count().ShouldEqual(3);
-                context.Contracts.IgnoreQueryFilters().Count().ShouldEqual(9);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            logs.Count(x => _selectMatchRegex.IsMatch(x)).ShouldEqual(7);
+            status.Result.ShouldEqual(7 + 6);
+            testContext.Employees.Count().ShouldEqual(4);
+            testContext.Employees.IgnoreQueryFilters().Count().ShouldEqual(11);
+            testContext.Contracts.Count().ShouldEqual(3);
+            testContext.Contracts.IgnoreQueryFilters().Count().ShouldEqual(9);
         }
 
         //------------------------------------------------------------
@@ -398,18 +370,16 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
             //SETUP
             var userId = Guid.NewGuid();
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options, userId))
-            {
-                context.Database.EnsureCreated();
+            using var context = new CascadeSoftDelDbContext(options, userId);
+            context.Database.EnsureCreated();
 
-                //ATTEMPT
-                var company = Company.SeedCompanyWithQuotes(context, userId);
+            //ATTEMPT
+            var company = Company.SeedCompanyWithQuotes(context, userId);
 
-                //VERIFY
-                context.Companies.Count().ShouldEqual(1);
-                context.Quotes.Count().ShouldEqual(4);
-                context.Set<QuotePrice>().Count().ShouldEqual(4);
-            }
+            //VERIFY
+            context.Companies.Count().ShouldEqual(1);
+            context.Quotes.Count().ShouldEqual(4);
+            context.Set<QuotePrice>().Count().ShouldEqual(4);
         }
 
         [Fact]
@@ -418,22 +388,20 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
             //SETUP
             var userId = Guid.NewGuid();
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options, userId))
-            {
-                context.Database.EnsureCreated();
-                var company = Company.SeedCompanyWithQuotes(context, userId);
+            using var context = new CascadeSoftDelDbContext(options, userId);
+            context.Database.EnsureCreated();
+            var company = Company.SeedCompanyWithQuotes(context, userId);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.SetCascadeSoftDelete(company);
+            //ATTEMPT
+            var status = service.SetCascadeSoftDelete(company);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1 + 4 + 4);
-                status.Message.ShouldEqual("You have soft deleted an entity and its 8 dependents");
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1 + 4 + 4);
+            status.Message.ShouldEqual("You have soft deleted an entity and its 8 dependents");
         }
 
         [Fact]
@@ -442,22 +410,20 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
             //SETUP
             var userId = Guid.NewGuid();
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options, userId))
-            {
-                context.Database.EnsureCreated();
-                var company = Company.SeedCompanyWithQuotes(context, userId);
+            using var context = new CascadeSoftDelDbContext(options, userId);
+            context.Database.EnsureCreated();
+            var company = Company.SeedCompanyWithQuotes(context, userId);
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
-                var status = service.SetCascadeSoftDelete(company);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var status = service.SetCascadeSoftDelete(company);
 
-                //ATTEMPT
-                var softDeleted = service.GetSoftDeletedEntries<Company>().ToList();
+            //ATTEMPT
+            var softDeleted = service.GetSoftDeletedEntries<Company>().ToList();
 
-                //VERIFY
-                softDeleted.Count.ShouldEqual(1);
-                softDeleted.Single().CompanyName.ShouldEqual(company.CompanyName);
-            }
+            //VERIFY
+            softDeleted.Count.ShouldEqual(1);
+            softDeleted.Single().CompanyName.ShouldEqual(company.CompanyName);
         }
 
         [Fact]
@@ -466,25 +432,23 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
             //SETUP
             var userId = Guid.NewGuid();
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options, userId))
-            {
-                context.Database.EnsureCreated();
-                var company = Company.SeedCompanyWithQuotes(context, userId);
-                company.Quotes.First().UserId = Guid.NewGuid();
-                context.SaveChanges();
+            using var context = new CascadeSoftDelDbContext(options, userId);
+            context.Database.EnsureCreated();
+            var company = Company.SeedCompanyWithQuotes(context, userId);
+            company.Quotes.First().UserId = Guid.NewGuid();
+            context.SaveChanges();
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.SetCascadeSoftDelete(company);
+            //ATTEMPT
+            var status = service.SetCascadeSoftDelete(company);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1 + 3 + 3);
-                status.Message.ShouldEqual("You have soft deleted an entity and its 6 dependents");
-                context.Quotes.IgnoreQueryFilters().Count(x => x.SoftDeleteLevel != 0).ShouldEqual(3);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1 + 3 + 3);
+            status.Message.ShouldEqual("You have soft deleted an entity and its 6 dependents");
+            context.Quotes.IgnoreQueryFilters().Count(x => x.SoftDeleteLevel != 0).ShouldEqual(3);
         }
 
         [Fact]
@@ -493,25 +457,23 @@ namespace Test.UnitTests.CascadeSoftDeleteTests
             //SETUP
             var userId = Guid.NewGuid();
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options, userId))
-            {
-                context.Database.EnsureCreated();
-                var company = Company.SeedCompanyWithQuotes(context, userId);
-                company.Quotes.First().PriceInfo.UserId = Guid.NewGuid();
-                context.SaveChanges();
+            using var context = new CascadeSoftDelDbContext(options, userId);
+            context.Database.EnsureCreated();
+            var company = Company.SeedCompanyWithQuotes(context, userId);
+            company.Quotes.First().PriceInfo.UserId = Guid.NewGuid();
+            context.SaveChanges();
 
-                var config = new ConfigCascadeDeleteWithUserId(context);
-                var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
+            var config = new ConfigCascadeDeleteWithUserId(context);
+            var service = new CascadeSoftDelService<ICascadeSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.SetCascadeSoftDelete(company);
+            //ATTEMPT
+            var status = service.SetCascadeSoftDelete(company);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1 + 4 + 3);
-                status.Message.ShouldEqual("You have soft deleted an entity and its 7 dependents");
-                context.Set<QuotePrice>().IgnoreQueryFilters().Count(x => x.SoftDeleteLevel != 0).ShouldEqual(3);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1 + 4 + 3);
+            status.Message.ShouldEqual("You have soft deleted an entity and its 7 dependents");
+            context.Set<QuotePrice>().IgnoreQueryFilters().Count(x => x.SoftDeleteLevel != 0).ShouldEqual(3);
         }
 
     }

--- a/Test/UnitTests/OtherTests/TestSoftDeleteConfiguration.cs
+++ b/Test/UnitTests/OtherTests/TestSoftDeleteConfiguration.cs
@@ -34,30 +34,28 @@ namespace Test.UnitTests.OtherTests
             //SETUP
             var currentUser = Guid.NewGuid();
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options, currentUser))
-            {
-                context.Database.EnsureCreated();
-                var order1 = new Order
-                    { OrderRef = "Cur user Order, soft del", SoftDeleted = true, UserId = currentUser };
-                var order2 = new Order
-                    { OrderRef = "Cur user Order", SoftDeleted = false, UserId = currentUser };
-                var order3 = new Order
-                    { OrderRef = "Diff user Order", SoftDeleted = true, UserId = Guid.NewGuid() };
-                context.AddRange(order1, order2, order3);
-                context.SaveChanges();
+            using var context = new SingleSoftDelDbContext(options, currentUser);
+            context.Database.EnsureCreated();
+            var order1 = new Order
+            { OrderRef = "Cur user Order, soft del", SoftDeleted = true, UserId = currentUser };
+            var order2 = new Order
+            { OrderRef = "Cur user Order", SoftDeleted = false, UserId = currentUser };
+            var order3 = new Order
+            { OrderRef = "Diff user Order", SoftDeleted = true, UserId = Guid.NewGuid() };
+            context.AddRange(order1, order2, order3);
+            context.SaveChanges();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
+            var config = new ConfigSoftDeleteWithUserId(context);
 
-                //ATTEMPT
-                var query = context.Orders.IgnoreQueryFilters().Where(
-                        config.FilterToGetValueSingleSoftDeletedEntities<Order, ISingleSoftDelete>())
-                    .Select(x => x.OrderRef);
-                var result = query.ToList();
+            //ATTEMPT
+            var query = context.Orders.IgnoreQueryFilters().Where(
+                    config.FilterToGetValueSingleSoftDeletedEntities<Order, ISingleSoftDelete>())
+                .Select(x => x.OrderRef);
+            var result = query.ToList();
 
-                //VERIFY
-                _output.WriteLine(query.ToQueryString());
-                result.Count.ShouldEqual(1);
-            }
+            //VERIFY
+            _output.WriteLine(query.ToQueryString());
+            result.Count.ShouldEqual(1);
         }
         [Fact]
         public void TestExpressionBuilderFormOtherFiltersOnlyWithUserIdOk()
@@ -65,30 +63,28 @@ namespace Test.UnitTests.OtherTests
             //SETUP
             var currentUser = Guid.NewGuid();
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options, currentUser))
-            {
-                context.Database.EnsureCreated();
-                var order1 = new Order
-                    { OrderRef = "Cur user Order, soft del", SoftDeleted = true, UserId = currentUser };
-                var order2 = new Order
-                    { OrderRef = "Cur user Order", SoftDeleted = false, UserId = currentUser };
-                var order3 = new Order
-                    { OrderRef = "Diff user Order", SoftDeleted = true, UserId = Guid.NewGuid() };
-                context.AddRange(order1, order2, order3);
-                context.SaveChanges();
+            using var context = new SingleSoftDelDbContext(options, currentUser);
+            context.Database.EnsureCreated();
+            var order1 = new Order
+            { OrderRef = "Cur user Order, soft del", SoftDeleted = true, UserId = currentUser };
+            var order2 = new Order
+            { OrderRef = "Cur user Order", SoftDeleted = false, UserId = currentUser };
+            var order3 = new Order
+            { OrderRef = "Diff user Order", SoftDeleted = true, UserId = Guid.NewGuid() };
+            context.AddRange(order1, order2, order3);
+            context.SaveChanges();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
+            var config = new ConfigSoftDeleteWithUserId(context);
 
-                //ATTEMPT
-                var query = context.Orders.IgnoreQueryFilters().Where(
-                        config.FilterToGetValueSingleSoftDeletedEntities<Order,ISingleSoftDelete>())
-                    .Select(x => x.OrderRef);
-                var result = query.ToList();
+            //ATTEMPT
+            var query = context.Orders.IgnoreQueryFilters().Where(
+                    config.FilterToGetValueSingleSoftDeletedEntities<Order, ISingleSoftDelete>())
+                .Select(x => x.OrderRef);
+            var result = query.ToList();
 
-                //VERIFY
-                _output.WriteLine(query.ToQueryString());
-                result.Count.ShouldEqual(1);
-            }
+            //VERIFY
+            _output.WriteLine(query.ToQueryString());
+            result.Count.ShouldEqual(1);
         }
 
         [Fact]
@@ -96,26 +92,24 @@ namespace Test.UnitTests.OtherTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book = new Book { Title = "test", SoftDeleted = true};
-                context.Add(book);
-                context.SaveChanges();
+            using var context = new SingleSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var book = new Book { Title = "test", SoftDeleted = true };
+            context.Add(book);
+            context.SaveChanges();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
+            var config = new ConfigSoftDeleteWithUserId(context);
 
-                //ATTEMPT
-                var getSoftValue = config.GetSoftDeleteValue.Compile().Invoke(book);
-                getSoftValue.ShouldBeTrue();
-                var query = context.Books.IgnoreQueryFilters().Where(config.GetSoftDeleteValue).Cast<Book>()
-                    .Select(x => x.Title.Length);
-                var result = query.ToList();
+            //ATTEMPT
+            var getSoftValue = config.GetSoftDeleteValue.Compile().Invoke(book);
+            getSoftValue.ShouldBeTrue();
+            var query = context.Books.IgnoreQueryFilters().Where(config.GetSoftDeleteValue).Cast<Book>()
+                .Select(x => x.Title.Length);
+            var result = query.ToList();
 
-                //VERIFY
-                _output.WriteLine(query.ToQueryString());
-                result.Count.ShouldEqual(1);
-            }
+            //VERIFY
+            _output.WriteLine(query.ToQueryString());
+            result.Count.ShouldEqual(1);
         }
 
 
@@ -125,32 +119,30 @@ namespace Test.UnitTests.OtherTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<CascadeSoftDelDbContext>();
-            using (var context = new CascadeSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var ceo = Employee.SeedEmployeeSoftDel(context);
-                ceo.SoftDeleteLevel = 1;
-                ceo.WorksFromMe.First().SoftDeleteLevel = 1;
-                context.SaveChanges();
+            using var context = new CascadeSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var ceo = Employee.SeedEmployeeSoftDel(context);
+            ceo.SoftDeleteLevel = 1;
+            ceo.WorksFromMe.First().SoftDeleteLevel = 1;
+            context.SaveChanges();
 
-                Expression<Func<ICascadeSoftDelete, byte>> expression = entity => entity.SoftDeleteLevel;
+            Expression<Func<ICascadeSoftDelete, byte>> expression = entity => entity.SoftDeleteLevel;
 
-                var parameter = Expression.Parameter(typeof(ICascadeSoftDelete), expression.Parameters.Single().Name);
-                var left = Expression.Invoke(expression,  parameter);
-                var right = Expression.Constant((byte)1, typeof(byte));
-                var equal = Expression.Equal(left, right);
-                var dynamicFilter = Expression.Lambda<Func<ICascadeSoftDelete, bool>>(equal, parameter);
+            var parameter = Expression.Parameter(typeof(ICascadeSoftDelete), expression.Parameters.Single().Name);
+            var left = Expression.Invoke(expression, parameter);
+            var right = Expression.Constant((byte)1, typeof(byte));
+            var equal = Expression.Equal(left, right);
+            var dynamicFilter = Expression.Lambda<Func<ICascadeSoftDelete, bool>>(equal, parameter);
 
-               //ATTEMPT
-               var query = context.Employees.IgnoreQueryFilters()
-                   .Where(dynamicFilter).Cast<Employee>()
-                   .Select(x => x.Name);
-                var result = query.ToList();
+            //ATTEMPT
+            var query = context.Employees.IgnoreQueryFilters()
+                .Where(dynamicFilter).Cast<Employee>()
+                .Select(x => x.Name);
+            var result = query.ToList();
 
-                //VERIFY
-                _output.WriteLine(query.ToQueryString());
-                result.Count.ShouldEqual(2);
-            }
+            //VERIFY
+            _output.WriteLine(query.ToQueryString());
+            result.Count.ShouldEqual(2);
         }
     }
 }

--- a/Test/UnitTests/SingleSoftDeleteTests/TestHardDeleteSoftDelete.cs
+++ b/Test/UnitTests/SingleSoftDeleteTests/TestHardDeleteSoftDelete.cs
@@ -25,32 +25,26 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book = context.AddBookWithReviewToDb();
+            
+            using var setupContext = new SingleSoftDelDbContext(options);
+            setupContext.Database.EnsureCreated();
+            var book = setupContext.AddBookWithReviewToDb();
+            var setupConfig = new ConfigSoftDeleteWithUserId(setupContext);
+            var setupService = new SingleSoftDeleteService<ISingleSoftDelete>(setupContext, setupConfig);
+            var setupStatus = setupService.SetSoftDelete(book);
+            setupStatus.IsValid.ShouldBeTrue(setupStatus.GetAllErrors());
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
-                var status = service.SetSoftDelete(book);
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            using var attemptContext = new SingleSoftDelDbContext(options);
+            var attemptConfig = new ConfigSoftDeleteWithUserId(attemptContext);
+            var attemptService = new SingleSoftDeleteService<ISingleSoftDelete>(attemptContext, attemptConfig);
+            //ATTEMPT
+            var attemptStatus = attemptService.HardDeleteSoftDeletedEntry(attemptContext.Books.IgnoreQueryFilters().Single());
+            //VERIFY
+            attemptStatus.IsValid.ShouldBeTrue(attemptStatus.GetAllErrors());
+            attemptStatus.Result.ShouldEqual(1);
 
-                //ATTEMPT
-                var status = service.HardDeleteSoftDeletedEntry(context.Books.IgnoreQueryFilters().Single());
-
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1);
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Books.IgnoreQueryFilters().Count().ShouldEqual(0);
-            }
+            using var testContext = new SingleSoftDelDbContext(options);
+            testContext.Books.IgnoreQueryFilters().Count().ShouldEqual(0);
         }
 
         [Fact]
@@ -58,32 +52,26 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book = context.AddBookWithReviewToDb();
+            
+            using var setupContext = new SingleSoftDelDbContext(options);            
+            setupContext.Database.EnsureCreated();
+            var book = setupContext.AddBookWithReviewToDb();
+            var setupConfig = new ConfigSoftDeleteWithUserId(setupContext);
+            var setupService = new SingleSoftDeleteService<ISingleSoftDelete>(setupContext, setupConfig);
+            var setupStatus = setupService.SetSoftDelete(book);
+            setupStatus.IsValid.ShouldBeTrue(setupStatus.GetAllErrors());
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
-                var status = service.SetSoftDelete(book);
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
-
-                //ATTEMPT
-                var status = service.HardDeleteSoftDeletedEntry(context.Books.IgnoreQueryFilters().Single(), false);
-                context.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
-                context.SaveChanges();
-                context.Books.IgnoreQueryFilters().Count().ShouldEqual(0);
-
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1);
-
-            }
+            using var testContext = new SingleSoftDelDbContext(options);
+            var testConfig = new ConfigSoftDeleteWithUserId(testContext);
+            var testService = new SingleSoftDeleteService<ISingleSoftDelete>(testContext, testConfig);
+            //ATTEMPT
+            var testStatus = testService.HardDeleteSoftDeletedEntry(testContext.Books.IgnoreQueryFilters().Single(), false);
+            testContext.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
+            testContext.SaveChanges();
+            testContext.Books.IgnoreQueryFilters().Count().ShouldEqual(0);
+            //VERIFY
+            testStatus.IsValid.ShouldBeTrue(testStatus.GetAllErrors());
+            testStatus.Result.ShouldEqual(1);
         }
 
         [Fact]
@@ -91,32 +79,27 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book = context.AddBookWithReviewToDb();
+            
+            using var setupContext = new SingleSoftDelDbContext(options);
+            setupContext.Database.EnsureCreated();
+            var book = setupContext.AddBookWithReviewToDb();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
-                var status = service.SetSoftDelete(book);
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            var setupConfig = new ConfigSoftDeleteWithUserId(setupContext);
+            var setupService = new SingleSoftDeleteService<ISingleSoftDelete>(setupContext, setupConfig);
+            var setupStatus = setupService.SetSoftDelete(book);
+            setupStatus.IsValid.ShouldBeTrue(setupStatus.GetAllErrors());
 
-                //ATTEMPT
-                var status = service.HardDeleteViaKeys<Book>(context.Books.IgnoreQueryFilters().Single().Id);
-
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1);
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Books.IgnoreQueryFilters().Count().ShouldEqual(0);
-            }
+            using var attemptContext = new SingleSoftDelDbContext(options);            
+            var attemptConfig = new ConfigSoftDeleteWithUserId(attemptContext);
+            var attemptService = new SingleSoftDeleteService<ISingleSoftDelete>(attemptContext, attemptConfig);
+            //ATTEMPT
+            var attemptStatus = attemptService.HardDeleteViaKeys<Book>(attemptContext.Books.IgnoreQueryFilters().Single().Id);
+            //VERIFY
+            attemptStatus.IsValid.ShouldBeTrue(attemptStatus.GetAllErrors());
+            attemptStatus.Result.ShouldEqual(1);
+            
+            using var testContext = new SingleSoftDelDbContext(options);
+            testContext.Books.IgnoreQueryFilters().Count().ShouldEqual(0);
         }
 
         [Fact]
@@ -124,23 +107,21 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book = context.AddBookWithReviewToDb();
+            using var context = new SingleSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var book = context.AddBookWithReviewToDb();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
-                var status1 = service.SetSoftDelete(book);
-                status1.IsValid.ShouldBeTrue(status1.GetAllErrors());
+            var config = new ConfigSoftDeleteWithUserId(context);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            var status1 = service.SetSoftDelete(book);
+            status1.IsValid.ShouldBeTrue(status1.GetAllErrors());
 
-                //ATTEMPT
-                var status = service.HardDeleteViaKeys<Book>(234);
+            //ATTEMPT
+            var status = service.HardDeleteViaKeys<Book>(234);
 
-                //VERIFY
-                status.IsValid.ShouldBeFalse(status.GetAllErrors());
-                status.GetAllErrors().ShouldEqual("Could not find the entry you ask for.");
-            }
+            //VERIFY
+            status.IsValid.ShouldBeFalse(status.GetAllErrors());
+            status.GetAllErrors().ShouldEqual("Could not find the entry you ask for.");
         }
 
     }

--- a/Test/UnitTests/SingleSoftDeleteTests/TestResetSoftDeleteAndGetSoftDeleted.cs
+++ b/Test/UnitTests/SingleSoftDeleteTests/TestResetSoftDeleteAndGetSoftDeleted.cs
@@ -25,27 +25,24 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book = context.AddBookWithReviewToDb();
+            using var setupContext = new SingleSoftDelDbContext(options);
+            setupContext.Database.EnsureCreated();
+            var book = setupContext.AddBookWithReviewToDb();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
-                service.SetSoftDelete(book);
+            var config = new ConfigSoftDeleteWithUserId(setupContext);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(setupContext, config);
+            service.SetSoftDelete(book);
 
-                //ATTEMPT
-                var status = service.ResetSoftDelete(book);
+            //ATTEMPT
+            var status = service.ResetSoftDelete(book);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1);
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Books.Count().ShouldEqual(1);
-                context.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1);
+
+            using var testContext = new SingleSoftDelDbContext(options);
+            testContext.Books.Count().ShouldEqual(1);
+            testContext.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
         }
 
         [Fact]
@@ -53,26 +50,24 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book = context.AddBookWithReviewToDb();
+            using var context = new SingleSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var book = context.AddBookWithReviewToDb();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
-                service.SetSoftDelete(book);
+            var config = new ConfigSoftDeleteWithUserId(context);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            service.SetSoftDelete(book);
 
-                //ATTEMPT
-                var status = service.ResetSoftDelete(book, false);
-                context.Books.Count().ShouldEqual(0);
-                context.SaveChanges();
-                context.Books.Count().ShouldEqual(1);
+            //ATTEMPT
+            var status = service.ResetSoftDelete(book, false);
+            context.Books.Count().ShouldEqual(0);
+            context.SaveChanges();
+            context.Books.Count().ShouldEqual(1);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1);
-                context.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1);
+            context.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
         }
 
         [Fact]
@@ -80,30 +75,27 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                context.Database.EnsureCreated();
-                var bookDdd = new BookDDD("Test");
-                context.Add(bookDdd);
-                context.SaveChanges();
+            using var setupContext = new SingleSoftDelDbContext(options);
+            setupContext.Database.EnsureCreated();
+            setupContext.Database.EnsureCreated();
+            var bookDdd = new BookDDD("Test");
+            setupContext.Add(bookDdd);
+            setupContext.SaveChanges();
 
-                var config = new ConfigSoftDeleteDDD();
-                var service = new SingleSoftDeleteService<ISingleSoftDeletedDDD>(context, config);
-                service.SetSoftDelete(bookDdd);
+            var config = new ConfigSoftDeleteDDD();
+            var service = new SingleSoftDeleteService<ISingleSoftDeletedDDD>(setupContext, config);
+            service.SetSoftDelete(bookDdd);
 
-                //ATTEMPT
-                var status = service.ResetSoftDelete(bookDdd);
+            //ATTEMPT
+            var status = service.ResetSoftDelete(bookDdd);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1);
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.BookDdds.Count().ShouldEqual(1);
-                context.BookDdds.IgnoreQueryFilters().Count().ShouldEqual(1);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1);
+
+            using var testContext = new SingleSoftDelDbContext(options);
+            testContext.BookDdds.Count().ShouldEqual(1);
+            testContext.BookDdds.IgnoreQueryFilters().Count().ShouldEqual(1);
         }
 
         [Fact]
@@ -112,28 +104,25 @@ namespace Test.UnitTests.SingleSoftDeleteTests
             //SETUP
             int bookId;
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                bookId = context.AddBookWithReviewToDb().Id;
+            using var setupContext = new SingleSoftDelDbContext(options);
+            setupContext.Database.EnsureCreated();
+            bookId = setupContext.AddBookWithReviewToDb().Id;
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
-                var status1 = service.SetSoftDeleteViaKeys<Book>(bookId);
-                status1.IsValid.ShouldBeTrue(status1.GetAllErrors());
+            var config = new ConfigSoftDeleteWithUserId(setupContext);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(setupContext, config);
+            var status1 = service.SetSoftDeleteViaKeys<Book>(bookId);
+            status1.IsValid.ShouldBeTrue(status1.GetAllErrors());
 
-                //ATTEMPT
-                var status2 = service.ResetSoftDeleteViaKeys<Book>(bookId);
+            //ATTEMPT
+            var status2 = service.ResetSoftDeleteViaKeys<Book>(bookId);
 
-                //VERIFY
-                status2.IsValid.ShouldBeTrue(status2.GetAllErrors());
-                status2.Result.ShouldEqual(1);
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Books.Count().ShouldEqual(1);
-                context.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
-            }
+            //VERIFY
+            status2.IsValid.ShouldBeTrue(status2.GetAllErrors());
+            status2.Result.ShouldEqual(1);
+
+            using var testContext = new SingleSoftDelDbContext(options);
+            testContext.Books.Count().ShouldEqual(1);
+            testContext.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
         }
 
         [Fact]
@@ -143,35 +132,32 @@ namespace Test.UnitTests.SingleSoftDeleteTests
             var currentUser = Guid.NewGuid();
             int bookId;
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var order1 = new Order
-                    { OrderRef = "Cur user Order, soft del", SoftDeleted = true, UserId = currentUser };
-                var order2 = new Order
-                    { OrderRef = "Cur user Order", SoftDeleted = false, UserId = currentUser };
-                var order3 = new Order
-                    { OrderRef = "Diff user Order", SoftDeleted = true, UserId = Guid.NewGuid() };
-                var order4 = new Order
-                    { OrderRef = "Diff user Order", SoftDeleted = false, UserId = Guid.NewGuid() };
-                context.AddRange(order1, order2, order3, order4);
-                context.SaveChanges();
-                bookId = order1.Id;
-            }
-            using (var context = new SingleSoftDelDbContext(options, currentUser))
-            {
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            using var setupContext = new SingleSoftDelDbContext(options);
+            setupContext.Database.EnsureCreated();
+            var order1 = new Order
+                { OrderRef = "Cur user Order, soft del", SoftDeleted = true, UserId = currentUser };
+            var order2 = new Order
+                { OrderRef = "Cur user Order", SoftDeleted = false, UserId = currentUser };
+            var order3 = new Order
+                { OrderRef = "Diff user Order", SoftDeleted = true, UserId = Guid.NewGuid() };
+            var order4 = new Order
+                { OrderRef = "Diff user Order", SoftDeleted = false, UserId = Guid.NewGuid() };
+            setupContext.AddRange(order1, order2, order3, order4);
+            setupContext.SaveChanges();
+            bookId = order1.Id;
+            
+            using var testContext = new SingleSoftDelDbContext(options, currentUser);
+            var config = new ConfigSoftDeleteWithUserId(testContext);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(testContext, config);
 
-                //ATTEMPT
-                var status = service.ResetSoftDeleteViaKeys<Order>(bookId);
+            //ATTEMPT
+            var status = service.ResetSoftDeleteViaKeys<Order>(bookId);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1);
-                context.Orders.IgnoreQueryFilters().Count().ShouldEqual(4);
-                context.Orders.Count().ShouldEqual(2);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1);
+            testContext.Orders.IgnoreQueryFilters().Count().ShouldEqual(4);
+            testContext.Orders.Count().ShouldEqual(2);
         }
 
         [Fact]
@@ -181,35 +167,32 @@ namespace Test.UnitTests.SingleSoftDeleteTests
             var currentUser = Guid.NewGuid();
             int bookId;
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var order1 = new Order
-                    { OrderRef = "Cur user Order, soft del", SoftDeleted = true, UserId = currentUser };
-                var order2 = new Order
-                    { OrderRef = "Cur user Order", SoftDeleted = false, UserId = currentUser };
-                var order3 = new Order
-                    { OrderRef = "Diff user Order", SoftDeleted = true, UserId = Guid.NewGuid() };
-                var order4 = new Order
-                    { OrderRef = "Diff user Order", SoftDeleted = false, UserId = Guid.NewGuid() };
-                context.AddRange(order1, order2, order3, order4);
-                context.SaveChanges();
-                bookId = order3.Id;
-            }
-            using (var context = new SingleSoftDelDbContext(options, currentUser))
-            {
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            using var setupContext = new SingleSoftDelDbContext(options);
+            setupContext.Database.EnsureCreated();
+            var order1 = new Order
+                { OrderRef = "Cur user Order, soft del", SoftDeleted = true, UserId = currentUser };
+            var order2 = new Order
+                { OrderRef = "Cur user Order", SoftDeleted = false, UserId = currentUser };
+            var order3 = new Order
+                { OrderRef = "Diff user Order", SoftDeleted = true, UserId = Guid.NewGuid() };
+            var order4 = new Order
+                { OrderRef = "Diff user Order", SoftDeleted = false, UserId = Guid.NewGuid() };
+            setupContext.AddRange(order1, order2, order3, order4);
+            setupContext.SaveChanges();
+            bookId = order3.Id;
+            
+            using var testContext = new SingleSoftDelDbContext(options, currentUser);
+            var config = new ConfigSoftDeleteWithUserId(testContext);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(testContext, config);
 
-                //ATTEMPT
-                var status = service.ResetSoftDeleteViaKeys<Order>(bookId);
+            //ATTEMPT
+            var status = service.ResetSoftDeleteViaKeys<Order>(bookId);
 
-                //VERIFY
-                status.IsValid.ShouldBeFalse();
-                status.GetAllErrors().ShouldEqual("Could not find the entry you ask for.");
-                context.Orders.IgnoreQueryFilters().Count().ShouldEqual(4);
-                context.Orders.Count().ShouldEqual(1);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeFalse();
+            status.GetAllErrors().ShouldEqual("Could not find the entry you ask for.");
+            testContext.Orders.IgnoreQueryFilters().Count().ShouldEqual(4);
+            testContext.Orders.Count().ShouldEqual(1);
         }
 
         //-------------------------------------------
@@ -220,32 +203,29 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book1 = context.AddBookWithReviewToDb("test1");
-                var book2 = context.AddBookWithReviewToDb("test2");
+            using var setupContext = new SingleSoftDelDbContext(options);            
+            setupContext.Database.EnsureCreated();
+            var book1 = setupContext.AddBookWithReviewToDb("test1");
+            var book2 = setupContext.AddBookWithReviewToDb("test2");
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
-                var status = service.SetSoftDelete(book1);
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            var setupConfig = new ConfigSoftDeleteWithUserId(setupContext);
+            var setupService = new SingleSoftDeleteService<ISingleSoftDelete>(setupContext, setupConfig);
+            var status = setupService.SetSoftDelete(book1);
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
 
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            
+            using var testContext = new SingleSoftDelDbContext(options);
+            var testConfig = new ConfigSoftDeleteWithUserId(testContext);
+            var testService = new SingleSoftDeleteService<ISingleSoftDelete>(testContext, testConfig);
 
-                //ATTEMPT
-                var softDelBooks = service.GetSoftDeletedEntries<Book>().ToList();
+            //ATTEMPT
+            var softDelBooks = testService.GetSoftDeletedEntries<Book>().ToList();
 
-                //VERIFY
-                softDelBooks.Count.ShouldEqual(1);
-                softDelBooks.Single().Title.ShouldEqual("test1");
-                context.Books.Count().ShouldEqual(1);
-                context.Books.IgnoreQueryFilters().Count().ShouldEqual(2);
-            }
+            //VERIFY
+            softDelBooks.Count.ShouldEqual(1);
+            softDelBooks.Single().Title.ShouldEqual("test1");
+            testContext.Books.Count().ShouldEqual(1);
+            testContext.Books.IgnoreQueryFilters().Count().ShouldEqual(2);
         }
 
         [Fact]
@@ -254,35 +234,32 @@ namespace Test.UnitTests.SingleSoftDeleteTests
             //SETUP
             var currentUser = Guid.NewGuid();
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var order1 = new Order
-                    { OrderRef = "Cur user Order, soft del", SoftDeleted = true, UserId = currentUser};
-                var order2 = new Order
-                    { OrderRef = "Cur user Order", SoftDeleted = false, UserId = currentUser };
-                var order3 = new Order
-                    { OrderRef = "Diff user Order", SoftDeleted = true, UserId = Guid.NewGuid() };
-                var order4 = new Order
-                    { OrderRef = "Diff user Order", SoftDeleted = false, UserId = Guid.NewGuid() };
-                context.AddRange(order1, order2, order3, order4);
-                context.SaveChanges();
-            }
-            using (var context = new SingleSoftDelDbContext(options, currentUser))
-            {
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            using var setupContext = new SingleSoftDelDbContext(options);            
+            setupContext.Database.EnsureCreated();
+            var order1 = new Order
+                { OrderRef = "Cur user Order, soft del", SoftDeleted = true, UserId = currentUser};
+            var order2 = new Order
+                { OrderRef = "Cur user Order", SoftDeleted = false, UserId = currentUser };
+            var order3 = new Order
+                { OrderRef = "Diff user Order", SoftDeleted = true, UserId = Guid.NewGuid() };
+            var order4 = new Order
+                { OrderRef = "Diff user Order", SoftDeleted = false, UserId = Guid.NewGuid() };
+            setupContext.AddRange(order1, order2, order3, order4);
+            setupContext.SaveChanges();
 
-                //ATTEMPT
-                var orders = service.GetSoftDeletedEntries<Order>().ToList();
+            using var testContext = new SingleSoftDelDbContext(options, currentUser);
+            var config = new ConfigSoftDeleteWithUserId(testContext);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(testContext, config);
 
-                //VERIFY
-                orders.Count.ShouldEqual(1);
-                orders.Single(x => x.UserId == currentUser).OrderRef.ShouldEqual("Cur user Order, soft del");
-                context.Orders.IgnoreQueryFilters().Count().ShouldEqual(4);
-                var all = context.Orders.IgnoreQueryFilters().ToList();
-                context.Orders.Count().ShouldEqual(1);
-            }
+            //ATTEMPT
+            var orders = service.GetSoftDeletedEntries<Order>().ToList();
+
+            //VERIFY
+            orders.Count.ShouldEqual(1);
+            orders.Single(x => x.UserId == currentUser).OrderRef.ShouldEqual("Cur user Order, soft del");
+            testContext.Orders.IgnoreQueryFilters().Count().ShouldEqual(4);
+            var all = testContext.Orders.IgnoreQueryFilters().ToList();
+            testContext.Orders.Count().ShouldEqual(1);
         }
     }
 }

--- a/Test/UnitTests/SingleSoftDeleteTests/TestSetSoftDelete.cs
+++ b/Test/UnitTests/SingleSoftDeleteTests/TestSetSoftDelete.cs
@@ -24,21 +24,17 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
+            using var setupContext = new SingleSoftDelDbContext(options);
+            setupContext.Database.EnsureCreated();
 
-                //ATTEMPT
-                context.AddBookWithReviewToDb();
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                //VERIFY
-                var book = context.Books.Include(x => x.Reviews).Single();
-                book.Title.ShouldEqual("test");
-                book.Reviews.ShouldNotBeNull();
-                book.Reviews.Single().NumStars.ShouldEqual(1);
-            }
+            //ATTEMPT
+            setupContext.AddBookWithReviewToDb();
+            using var testContext = new SingleSoftDelDbContext(options);
+            //VERIFY
+            var book = testContext.Books.Include(x => x.Reviews).Single();
+            book.Title.ShouldEqual("test");
+            book.Reviews.ShouldNotBeNull();
+            book.Reviews.Single().NumStars.ShouldEqual(1);
         }
 
         [Fact]
@@ -46,26 +42,23 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book = context.AddBookWithReviewToDb();
+            using var setupContext = new SingleSoftDelDbContext(options);
+            setupContext.Database.EnsureCreated();
+            var book = setupContext.AddBookWithReviewToDb();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            var config = new ConfigSoftDeleteWithUserId(setupContext);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(setupContext, config);
 
-                //ATTEMPT
-                var status = service.SetSoftDelete(book);
+            //ATTEMPT
+            var status = service.SetSoftDelete(book);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1);
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Books.Count().ShouldEqual(0);
-                context.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1);
+
+            using var testContext = new SingleSoftDelDbContext(options);
+            testContext.Books.Count().ShouldEqual(0);
+            testContext.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
         }
 
         [Fact]
@@ -73,25 +66,23 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book = context.AddBookWithReviewToDb();
+            using var context = new SingleSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var book = context.AddBookWithReviewToDb();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            var config = new ConfigSoftDeleteWithUserId(context);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.SetSoftDelete(book, false);
-                context.Books.Count().ShouldEqual(1);
-                context.SaveChanges();
-                context.Books.Count().ShouldEqual(0);
+            //ATTEMPT
+            var status = service.SetSoftDelete(book, false);
+            context.Books.Count().ShouldEqual(1);
+            context.SaveChanges();
+            context.Books.Count().ShouldEqual(0);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1);
-                context.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1);
+            context.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
         }
 
         [Fact]
@@ -99,26 +90,23 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book = context.AddBookWithReviewToDb();
+            using var setupContext = new SingleSoftDelDbContext(options);
+            setupContext.Database.EnsureCreated();
+            var book = setupContext.AddBookWithReviewToDb();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            var config = new ConfigSoftDeleteWithUserId(setupContext);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(setupContext, config);
 
-                //ATTEMPT
-                var status = service.SetSoftDeleteViaKeys<Book>(book.Id);
+            //ATTEMPT
+            var status = service.SetSoftDeleteViaKeys<Book>(book.Id);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1);
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Books.Count().ShouldEqual(0);
-                context.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1);
+
+            using var testContext = new SingleSoftDelDbContext(options);
+            testContext.Books.Count().ShouldEqual(0);
+            testContext.Books.IgnoreQueryFilters().Count().ShouldEqual(1);
         }
 
         [Fact]
@@ -126,20 +114,18 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book = context.AddBookWithReviewToDb();
+            using var context = new SingleSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var book = context.AddBookWithReviewToDb();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            var config = new ConfigSoftDeleteWithUserId(context);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
 
-                //ATTEMPT
-                var ex = Assert.Throws<ArgumentException>(() => service.SetSoftDeleteViaKeys<Book>(book));
+            //ATTEMPT
+            var ex = Assert.Throws<ArgumentException>(() => service.SetSoftDeleteViaKeys<Book>(book));
 
-                //VERIFY
-                ex.Message.ShouldEqual("Mismatch in keys: your provided key 1 (of 1) is of type Book but entity key's type is System.Int32 (Parameter 'keyValues')");
-            }
+            //VERIFY
+            ex.Message.ShouldEqual("Mismatch in keys: your provided key 1 (of 1) is of type Book but entity key's type is System.Int32 (Parameter 'keyValues')");
         }
 
         [Fact]
@@ -147,20 +133,18 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var book = context.AddBookWithReviewToDb();
+            using var context = new SingleSoftDelDbContext(options);
+            context.Database.EnsureCreated();
+            var book = context.AddBookWithReviewToDb();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            var config = new ConfigSoftDeleteWithUserId(context);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
 
-                //ATTEMPT
-                var ex = Assert.Throws<ArgumentException>(() => service.SetSoftDeleteViaKeys<Book>(1,2));
+            //ATTEMPT
+            var ex = Assert.Throws<ArgumentException>(() => service.SetSoftDeleteViaKeys<Book>(1, 2));
 
-                //VERIFY
-                ex.Message.ShouldEqual("Mismatch in keys: your provided 2 key(s) and the entity has 1 key(s) (Parameter 'keyValues')");
-            }
+            //VERIFY
+            ex.Message.ShouldEqual("Mismatch in keys: your provided 2 key(s) and the entity has 1 key(s) (Parameter 'keyValues')");
         }
 
         [Fact]
@@ -168,21 +152,19 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
+            using var context = new SingleSoftDelDbContext(options);
+            context.Database.EnsureCreated();
 
-                var config = new ConfigSoftDeleteWithUserId(context);
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            var config = new ConfigSoftDeleteWithUserId(context);
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.SetSoftDeleteViaKeys<Book>(123);
+            //ATTEMPT
+            var status = service.SetSoftDeleteViaKeys<Book>(123);
 
-                //VERIFY
-                status.IsValid.ShouldBeFalse();
-                status.GetAllErrors().ShouldEqual("Could not find the entry you ask for.");
-                status.Result.ShouldEqual(0);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeFalse();
+            status.GetAllErrors().ShouldEqual("Could not find the entry you ask for.");
+            status.Result.ShouldEqual(0);
         }
 
         [Fact]
@@ -190,20 +172,18 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
+            using var context = new SingleSoftDelDbContext(options);
+            context.Database.EnsureCreated();
 
-                var config = new ConfigSoftDeleteWithUserId(context) {NotFoundIsNotAnError = true};
-                var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
+            var config = new ConfigSoftDeleteWithUserId(context) { NotFoundIsNotAnError = true };
+            var service = new SingleSoftDeleteService<ISingleSoftDelete>(context, config);
 
-                //ATTEMPT
-                var status = service.SetSoftDeleteViaKeys<Book>(123);
+            //ATTEMPT
+            var status = service.SetSoftDeleteViaKeys<Book>(123);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(0);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(0);
         }
 
         //----------------------------------------
@@ -214,28 +194,25 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var bookDdd = new BookDDD("Test");
-                context.Add(bookDdd);
-                context.SaveChanges();
+            using var setupContext = new SingleSoftDelDbContext(options);
+            setupContext.Database.EnsureCreated();
+            var bookDdd = new BookDDD("Test");
+            setupContext.Add(bookDdd);
+            setupContext.SaveChanges();
 
-                var config = new ConfigSoftDeleteDDD();
-                var service = new SingleSoftDeleteService<ISingleSoftDeletedDDD>(context, config);
+            var config = new ConfigSoftDeleteDDD();
+            var service = new SingleSoftDeleteService<ISingleSoftDeletedDDD>(setupContext, config);
 
-                //ATTEMPT
-                var status = service.SetSoftDelete(bookDdd);
+            //ATTEMPT
+            var status = service.SetSoftDelete(bookDdd);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1);
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.BookDdds.Count().ShouldEqual(0);
-                context.BookDdds.IgnoreQueryFilters().Count().ShouldEqual(1);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1);
+
+            using var testContext = new SingleSoftDelDbContext(options);
+            testContext.BookDdds.Count().ShouldEqual(0);
+            testContext.BookDdds.IgnoreQueryFilters().Count().ShouldEqual(1);
         }
 
         [Fact]
@@ -243,28 +220,25 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         {
             //SETUP
             var options = SqliteInMemory.CreateOptions<SingleSoftDelDbContext>();
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.Database.EnsureCreated();
-                var bookDdd = new BookDDD("Test");
-                context.Add(bookDdd);
-                context.SaveChanges();
+            using var setupContext = new SingleSoftDelDbContext(options);
+            setupContext.Database.EnsureCreated();
+            var bookDdd = new BookDDD("Test");
+            setupContext.Add(bookDdd);
+            setupContext.SaveChanges();
 
-                var config = new ConfigSoftDeleteDDD();
-                var service = new SingleSoftDeleteService<ISingleSoftDeletedDDD>(context, config);
+            var config = new ConfigSoftDeleteDDD();
+            var service = new SingleSoftDeleteService<ISingleSoftDeletedDDD>(setupContext, config);
 
-                //ATTEMPT
-                var status = service.SetSoftDeleteViaKeys<BookDDD>(bookDdd.Id);
+            //ATTEMPT
+            var status = service.SetSoftDeleteViaKeys<BookDDD>(bookDdd.Id);
 
-                //VERIFY
-                status.IsValid.ShouldBeTrue(status.GetAllErrors());
-                status.Result.ShouldEqual(1);
-            }
-            using (var context = new SingleSoftDelDbContext(options))
-            {
-                context.BookDdds.Count().ShouldEqual(0);
-                context.BookDdds.IgnoreQueryFilters().Count().ShouldEqual(1);
-            }
+            //VERIFY
+            status.IsValid.ShouldBeTrue(status.GetAllErrors());
+            status.Result.ShouldEqual(1);
+
+            using var testContext = new SingleSoftDelDbContext(options);
+            testContext.BookDdds.Count().ShouldEqual(0);
+            testContext.BookDdds.IgnoreQueryFilters().Count().ShouldEqual(1);
         }
 
 


### PR DESCRIPTION
In C# 8.0 'using' statements doesn't require braces. [https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement).

I have removed the braces from the 'using' statements in unit test cases. This is to avoid one level of indentation in code.