### PR TITLE
Rename unit test cases.

### DIFF
--- a/Test/UnitTests/SingleSoftDeleteTests/TestResetSoftDeleteAndGetSoftDeleted.cs
+++ b/Test/UnitTests/SingleSoftDeleteTests/TestResetSoftDeleteAndGetSoftDeleted.cs
@@ -137,7 +137,7 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         }
 
         [Fact]
-        public void TestHardDeleteViaKeysWithUserIdOk()
+        public void TestSoftDeleteServiceResetSoftDeleteViaKeysWithUserIdOk()
         {
             //SETUP
             var currentUser = Guid.NewGuid();
@@ -175,7 +175,7 @@ namespace Test.UnitTests.SingleSoftDeleteTests
         }
 
         [Fact]
-        public void TestHardDeleteViaKeysWithWrongUserIdBad()
+        public void TestSoftDeleteServiceResetSoftDeleteViaKeysWithWrongUserIdBad()
         {
             //SETUP
             var currentUser = Guid.NewGuid();


### PR DESCRIPTION
Rename two unit test cases because the unit test is to test the soft delete reset not hard delete but in the name there was hard delete. So I have fixed the name.